### PR TITLE
Add highlight.js syntax to integrations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Cedar relat
 ## Language and Platform Integrations
   - Go bindings [WASM based](https://github.com/Joffref/cedar) 
   - Go bindings [CGO based](https://github.com/iann0036/cedargo)
+  - [Highlight.js syntax](https://github.com/jasmaa/highlightjs-cedar)
 
 ## Articles
   - [Cedar vs Rego (OPA)](https://www.permit.io/blog/opa-vs-cedar)


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Add highlight.js syntax to integrations list


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
