### PR TITLE
Add ruby bindings to language support list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Cedar relat
 - Go bindings [WASM based](https://github.com/Joffref/cedar)
 - Go bindings [CGO based](https://github.com/iann0036/cedargo)
 - [Python bindings (cedarpy)](https://github.com/k9securityio/cedar-py)
+- Ruby bindings [cedar-policy-rb](https://github.com/elct9620/cedar-policy-rb)
 - [Tree Sitter grammar](https://github.com/chrnorm/tree-sitter-cedar)
 
 ## IDE and Editor Extensions


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add [cedar-policy-rb](https://github.com/elct9620/cedar-policy-rb) gem repository to unofficial language support list.


